### PR TITLE
collapse multiple first names together

### DIFF
--- a/R/metadata.R
+++ b/R/metadata.R
@@ -162,7 +162,7 @@ transform_metadata <- function(file, site_config, collection_config, metadata, a
     # compute first and last name
     metadata$author <- lapply(metadata$author, function(author) {
       names <- strsplit(author$name, '\\s+')[[1]]
-      author$first_name <- paste(utils::head(names, -1))
+      author$first_name <- paste(utils::head(names, -1), collapse = " ")
       author$last_name <- utils::tail(names, 1)
       author
     })


### PR DESCRIPTION
allows for multiple first names for same author (middle name use common in academic literature) and still have bibtex citation record formatted appropriately .

Previously yaml header:

```yaml
author:
  - name: Nicolas PJ Coutin
```

would result in the bibtex citation record to be rendered as:

```
@misc(coutin2017the,
  author = {c("Coutin, Nicolas", "Coutin,PJ") and Nislow, Corey},
  title = {The dark matter of personalized medicine: Non–genetic variation},
  url = {http://med-fom-ubcmj.sites.olt.ubc.ca/files/2017/08/CoutinNislow-PROOF.pdf},
  year = {2017}
}
```

Instead of:

```
@misc(coutin2017the,
  author = {Coutin, Nicolas PJ and Nislow, Corey},
  title = {The dark matter of personalized medicine: Non–genetic variation},
  url = {http://med-fom-ubcmj.sites.olt.ubc.ca/files/2017/08/CoutinNislow-PROOF.pdf},
  year = {2017}
}
```